### PR TITLE
Remove asyncio from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
 VERSION = '0.1.0'
 
-REQUIRED = ['asyncio']
+REQUIRED = []
 
 EXTRAS = {}
 


### PR DESCRIPTION
## Background

Conflicting setup requirement with standard library for Python 3.7 / 3.8

- This library supports an integration in Home Assistant.
- One or more of the requirements of this library (see below) conflicts with one or more standard library modules for Python 3.7 and/or 3.8.
- To avoid issues it would be good if this library would remove these conflicting requirements from your library setup requirements or use a condition to only install the requirements when using a lower Python version.
- If a `setup.py` file is used it means updating the `install_requires` list and removing or updating the conflicting requirements.
  - See this blog for how to use a condition in `install_requires`: https://hynek.me/articles/conditional-python-dependencies/
- Found conflicts:
  - `asyncio`

Thanks for your support of Home Assistant!

## Solution

- Since this library requires Python 3.7 as minimum version, `asyncio` is not required to be installed from PyPI.