### PR TITLE
Implement "feed" command support

### DIFF
--- a/pycoolmasternet_async/coolmasternet.py
+++ b/pycoolmasternet_async/coolmasternet.py
@@ -133,6 +133,7 @@ class CoolMasterNetUnit():
 
     async def set_thermostat(self, value):
         """Set the target temperature."""
+        rounded = round(value, 1)
         await self._make_unit_request(f"temp UID {value}")
         return await self.refresh()
 
@@ -145,3 +146,9 @@ class CoolMasterNetUnit():
         """Turn a unit off."""
         await self._make_unit_request("off UID")
         return await self.refresh()
+
+    async def feed(self, value):
+        """Provides ambient temperature hint to the unit."""
+        rounded = round(value, 1)
+        await self._make_unit_request(f"feed UID {rounded}")
+

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/OnFreund/pycoolmasternet-async'
 EMAIL = 'onfreund@gmail.com'
 AUTHOR = 'On Freund'
 REQUIRES_PYTHON = '>=3.7.0'
-VERSION = '0.1.2'
+VERSION = '0.1.3'
 
 REQUIRED = []
 


### PR DESCRIPTION
This implements a method to expose the `feed` command for use with Home Assistant (I'll open a PR there shortly as well). This would allow Home Assistant to provide the ambient temperature value to the HVAC based on HA-controlled sensors (in my case I'm using Bluetooth sensors which allows me to better position it than the built-in sensor of the HVAC thermostat).

Also, it rounds provided temperature values (to both "feed" as well as the existing "set temperature") to 1 decimal place which is the maximum precision supported by CoolMasterNet. This makes sure it doesn't break if someone accidentally provides a decimal or something with lots of digits.