### PR TITLE
Added additional commands to get unit information and other minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 
 .*.swp
 *.pyc
+/raz.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ __pycache__/
 
 .*.swp
 *.pyc
-/raz.py
+

--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ info = await cool.info()
 # Returns a dict of CoolMasterNetUnit objects. Keys are the unit IDs
 units = await cool.status()
 
+# turn on / off all units
+await cool.turn_on()
+await cool.turn_off()
+
+# get a specific unit and control / query it
 unit = units["L1.001"]
 
+# get unit id
 unit.unit_id
 
 # Temperature unit: Imperial, Celsius
@@ -48,13 +54,23 @@ unit.is_on
 unit = await unit.turn_on()
 unit = await unit.turn_off()
 
-# Fan speed: low, med, high, auto
+# unit fan speeds - a list of supported fan speeds of that unit (e.g. ['low', 'med', 'high'])
+unit.fan_speeds
+
+# Fan speed: very low, low, med, high, top, auto 
 unit.fan_speed
 unit = await unit.set_fan_speed('med')
 
-# Mode of operation: auto, cool, dry, fan, heat
+# unit modes - a list of supported operation modes (e.g. ['auto', 'cool', 'dry', 'fan', 'heat'])
+unit.modes
+
+# Unit mode of operation: auto, cool, dry, fan, heat
 unit.mode
 unit = await unit.set_mode('cool')
+
+# unit name - friendly name defined in CoolMasterNet
+unit.name
+
 
 # Get fresh info
 unit = await unit.refresh()

--- a/pycoolmasternet_async/__init__.py
+++ b/pycoolmasternet_async/__init__.py
@@ -1,2 +1,3 @@
 from .coolmasternet import CoolMasterNet
 from .coolmasternet import SWING_MODES
+from .coolmasternet import FAN_SPEEDS

--- a/pycoolmasternet_async/coolmasternet.py
+++ b/pycoolmasternet_async/coolmasternet.py
@@ -1,7 +1,15 @@
 import asyncio
 import re
 
+# possible HVAC modes
 _MODES = ["auto", "cool", "dry", "fan", "heat"]
+# possible FAN modes
+FAN_SPEEDS = ['very low', 'low', 'medium', 'high', 'top', 'auto']
+
+# The unit reports the above in one-letter codes (first letter):
+_FAN_CHAR_TO_SPEED = {v[0]: v for v in FAN_SPEEDS}
+
+MODES_TO_CHAR = {m[0]: m for m in _MODES}
 
 _SWING_CHAR_TO_NAME = {
     "a": "auto",
@@ -17,9 +25,12 @@ _SWING_NAME_TO_CHAR = {value: key for key, value in _SWING_CHAR_TO_NAME.items()}
 
 SWING_MODES = list(_SWING_CHAR_TO_NAME.values())
 
+_PROPS_COLUMNS = ['uid', 'name', 'visibility', 'modes', 'fan_speeds']
 
-class CoolMasterNet():
+
+class CoolMasterNet:
     """A connection to a coolmasternet bridge."""
+
     def __init__(self, host, port=10102, read_timeout=1, swing_support=False):
         """Initialize this CoolMasterNet instance to connect to a particular
         host at a particular port."""
@@ -28,20 +39,22 @@ class CoolMasterNet():
         self._read_timeout = read_timeout
         self._swing_support = swing_support
         self._concurrent_reads = asyncio.Semaphore(3)
+        self._props_data = None
 
-    async def _make_request(self, request):
+    async def _make_request(self, request, timeout=None):
         """Send a request to the CoolMasterNet and returns the response."""
+        timeout = timeout or self._read_timeout
         async with self._concurrent_reads:
 
             reader, writer = await asyncio.open_connection(self._host, self._port)
 
             try:
-                prompt = await asyncio.wait_for(reader.readuntil(b">"), self._read_timeout)
+                prompt = await asyncio.wait_for(reader.readuntil(b">"), timeout)
                 if prompt != b">":
                     raise ConnectionError("CoolMasterNet prompt not found")
 
                 writer.write((request + "\n").encode("ascii"))
-                response = await asyncio.wait_for(reader.readuntil(b"\n>"), self._read_timeout)
+                response = await asyncio.wait_for(reader.readuntil(b"\n>"), timeout)
 
                 data = response.decode("ascii")
                 if data.endswith("\n>"):
@@ -56,39 +69,74 @@ class CoolMasterNet():
                 await writer.wait_closed()
 
     async def info(self):
-        """Get the general info the this CoolMasterNet."""
+        """Get the general info of this CoolMasterNet."""
         raw = await self._make_request("set")
         lines = raw.strip().split("\r\n")
         key_values = [re.split(r"\s*:\s*", line, 1) for line in lines]
+        self._props_data = await self._props()
         return dict(key_values)
 
     async def status(self):
-        """Return a list of CoolMasterNetUnit objects with current status."""
+        """Return a list of CoolMasterNetUnit objects with current status & properties."""
+        if self._props_data is None:
+            self._props_data = await self._props()  # only fetch once
         status_lines = (await self._make_request("ls2")).strip().split("\r\n")
         return {
             key: unit
-            for unit, key in await asyncio.gather(
-                *(CoolMasterNetUnit.create(self, line[0:6], line) for line in status_lines))
+            for unit, key in (await asyncio.gather(
+                *(CoolMasterNetUnit.create(self, line[0:6], line, self._props_data[line[0:6]]) for line in
+                  status_lines)))
         }
 
+    async def _props(self):
+        """ Returns properties of the units - modes, name, fan speeds as a dict
+        unit_id->[name, visibility, modes, fan_modes]
+        The unit id is the same as in the unit's dict. Note data is static and does not change over time."""
+        props_lines = (await self._make_request("props")).strip().split("\r\n")
+        if len(props_lines) < 3:
+            return None
+        props = {}
+        for pline in props_lines[2:]:
+            p_item = [p.strip() for p in pline.split("|")[0:5]]
+            prop_dict = {m: p_item[i + 1] for i, m in enumerate(_PROPS_COLUMNS[1:])}
+            prop_dict['modes'] = [MODES_TO_CHAR[c] for c in [y.strip() for y in prop_dict['modes'].split(' ') if y]]
+            prop_dict['fan_speeds'] = [_FAN_CHAR_TO_SPEED[c] for c in
+                                       [y.strip() for y in prop_dict['fan_speeds'].split(' ') if y]]
+            props[p_item[0]] = prop_dict
+        return props
 
-class CoolMasterNetUnit():
+    async def all_on(self):
+        """Turn all units on. """
+        """ Note: command sometimes fail on some of the units and might be needed to call more than once.
+            due to issue with the bridge handling of this command"""
+        await self._make_request("allon", timeout=10)
+
+    async def all_off(self):
+        """Turn all units off."""
+        """ Note: command sometimes fail on some of the units and might be needed to call more than once.
+            due to issue with the bridge handling of this command"""
+        await self._make_request("alloff", timeout=10)
+
+
+class CoolMasterNetUnit:
     """An immutable snapshot of a unit."""
-    def __init__(self, bridge, unit_id, raw, swing_raw):
+
+    def __init__(self, bridge, unit_id, raw, swing_raw, props):
         """Initialize a unit snapshot."""
         self._raw = raw
         self._swing_raw = swing_raw
         self._unit_id = unit_id
         self._bridge = bridge
         self._parse()
+        self._props = props
 
     @classmethod
-    async def create(cls, bridge, unit_id, raw=None):
+    async def create(cls, bridge, unit_id, raw=None, props=None):
         if raw is None:
-            raw = (await bridge._make_request(f"ls2 {unit_id}")).strip()   
-        swing_raw = ((await bridge._make_request(f"query {unit_id} s")).strip() 
-            if bridge._swing_support else "")
-        return CoolMasterNetUnit(bridge, unit_id, raw, swing_raw), unit_id
+            raw = (await bridge._make_request(f"ls2 {unit_id}")).strip()
+        swing_raw = ((await bridge._make_request(f"query {unit_id} s")).strip()
+                     if bridge._swing_support else "")
+        return CoolMasterNetUnit(bridge, unit_id, raw, swing_raw, props), unit_id
 
     def _parse(self):
         fields = re.split(r"\s+", self._raw.strip())
@@ -121,7 +169,7 @@ class CoolMasterNetUnit():
     def is_on(self):
         """Is the unit on."""
         return self._is_on
-    
+
     @property
     def thermostat(self):
         """The target temperature."""
@@ -134,7 +182,7 @@ class CoolMasterNetUnit():
 
     @property
     def fan_speed(self):
-        """The fan spped."""
+        """The fan speed."""
         return self._fan_speed
 
     @property
@@ -160,7 +208,22 @@ class CoolMasterNetUnit():
     @property
     def temperature_unit(self):
         return self._temperature_unit
-    
+
+    @property
+    def fan_speeds(self):
+        """ return available fan speeds for this unit """
+        return self._props.get('fan_speeds', FAN_SPEEDS)
+
+    @property
+    def modes(self):
+        """ return available modes for this unit """
+        return self._props.get('modes', _MODES)
+
+    @property
+    def name(self):
+        """ return friendly name of this unit """
+        return self._props.get('name', '')
+
     async def set_fan_speed(self, value):
         """Set the fan speed."""
         await self._make_unit_request(f"fspeed UID {value}")
@@ -168,18 +231,17 @@ class CoolMasterNetUnit():
 
     async def set_mode(self, value):
         """Set the mode."""
-        if not value in _MODES:
+        if value not in _MODES:
             raise ValueError(
                 f"Unrecognized mode {value}. Valid values: {' '.join(_MODES)}"
             )
-
         await self._make_unit_request(value + " UID")
         return await self.refresh()
 
     async def set_thermostat(self, value):
         """Set the target temperature."""
         rounded = round(value, 1)
-        await self._make_unit_request(f"temp UID {value}")
+        await self._make_unit_request(f"temp UID {rounded}")
         return await self.refresh()
 
     async def set_swing(self, value):
@@ -194,7 +256,6 @@ class CoolMasterNetUnit():
             raise ValueError(
                 f"Unit {self._unit_id} doesn't support swing mode {value}."
             )
-
         return await self.refresh()
 
     async def turn_on(self):


### PR DESCRIPTION
Hi,
a.  added a query to 'props' of the units, so each unit name (friendly name), allowed fan and operation modes are now available.  This allows for example Home Assistant to see the unit name and not L.001 type names.
b. added the commands to turn off and on all units (allon,alloff coolmasternet commands)
c. minor PEP, spelling, comments and READMEupdates/corrections.
d. added ability to include longer timeout  - needed for the all_on/off commands which takes significant time to respond.

Tested on my home installation with 14 units.
RS