### PR TITLE
Support a legacy variant of the coolmaster protocol

### DIFF
--- a/pycoolmasternet_async/coolmasternet.py
+++ b/pycoolmasternet_async/coolmasternet.py
@@ -24,7 +24,7 @@ class ProtocolFormat(Enum):
 
     # An older protocol which is partially compatible with the Net variant,
     # supported models are 1000D, 2000S, 3000T, 4000M, 6000L, 7000F, 8000I(MH),
-    # 9000H and GG
+    # 9000H and CoolMaster G
     LEGACY = "legacy"
 
 class CoolMasterNet():


### PR DESCRIPTION
Added seamless support for the CoolMaster protocol used with the following models:
1000D, 2000S, 3000T, 4000M, 6000L, 7000F, 8000I(MH), 9000H, and CoolMaster G.

This protocol is similar to the CoolMasterNet variant, with the following differences:
- Unit names are shorter.
- The `ls2` command does not exist; instead, `stat2` is used, which has a slightly different format.
- The `feed` command does not exist.

Please note that these models only have a serial port, whereas the library assumes a TCP/IP connection. Therefore, a TCP/IP-to-serial converter is required.